### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,48 @@
+# Dependabot configuration file for thejokers69/thejokers69
+# Automated dependency updates for Ruby/Bundler (Jekyll), GitHub Actions, and npm
+
+version: 2
+updates:
+  # Keep Ruby/Bundler dependencies up to date (for Jekyll)
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "ruby"
+    commit-message:
+      prefix: "📦"
+      include: "scope"
+
+  # Keep GitHub Actions up to date
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "🔧"
+      include: "scope"
+
+  # For JavaScript/npm dependencies (if any)
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "javascript"
+    ignore:
+      # Ignore major version updates for these packages
+      # as they might require significant changes
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    commit-message:
+      prefix: "📦"
+      include: "scope"


### PR DESCRIPTION
This pull request introduces a new Dependabot configuration file to automate dependency updates for Ruby/Bundler, GitHub Actions, and npm. The most important changes include the addition of schedules, labels, and commit message prefixes for each package ecosystem.

Dependabot configuration:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R1-R48): Added Dependabot configuration to automate updates for Ruby/Bundler (Jekyll), GitHub Actions, and npm. Each ecosystem has its own update schedule, labels, and commit message prefixes.

## Summary by Sourcery

Set up Dependabot configuration to automate dependency updates across multiple package ecosystems

CI:
- Configure Dependabot to automatically update dependencies for Ruby/Bundler, GitHub Actions, and npm with weekly and monthly schedules

Chores:
- Add `.github/dependabot.yml` to manage dependency updates with predefined settings