### PR TITLE
Create jekyll.yml

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -1,0 +1,65 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# Sample workflow for building and deploying a Jekyll site to GitHub Pages
+name: Deploy Jekyll site to Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["master"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Ruby
+        # https://github.com/ruby/setup-ruby/releases/tag/v1.207.0
+        uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4
+        with:
+          ruby-version: '3.1' # Not needed with a .ruby-version file
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+          cache-version: 0 # Increment this number if you need to re-download cached gems
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v5
+      - name: Build with Jekyll
+        # Outputs to the './_site' directory by default
+        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+        env:
+          JEKYLL_ENV: production
+      - name: Upload artifact
+        # Automatically uploads an artifact from the './_site' directory by default
+        uses: actions/upload-pages-artifact@v3
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Ruby
         # https://github.com/ruby/setup-ruby/releases/tag/v1.207.0
-        uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4
+        uses: ruby/setup-ruby@v1.207.0
         with:
           ruby-version: '3.1' # Not needed with a .ruby-version file
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for building and deploying a Jekyll site to GitHub Pages. The workflow is defined in the `.github/workflows/jekyll.yml` file. Here are the most important changes:

### New GitHub Actions Workflow

* A new workflow named `Deploy Jekyll site to Pages` has been added to automate the deployment of a Jekyll site to GitHub Pages.

### Workflow Configuration

* The workflow is triggered by pushes to the `master` branch and can also be manually triggered from the Actions tab.
* Permissions for `GITHUB_TOKEN` are set to allow reading contents, and writing to pages and id-token.
* Concurrency settings ensure only one deployment runs at a time without canceling in-progress runs.

### Jobs and Steps

* The `build` job runs on `ubuntu-latest`, checks out the repository, sets up Ruby, configures Pages, builds the Jekyll site, and uploads the build artifact.
* The `deploy` job runs on `ubuntu-latest`, depends on the `build` job, and deploys the site to GitHub Pages.

## Summary by Sourcery

Add GitHub Actions workflow for automated Jekyll site deployment to GitHub Pages

New Features:
- Implement automated deployment pipeline for Jekyll site using GitHub Actions

CI:
- Create a GitHub Actions workflow that builds and deploys a Jekyll site to GitHub Pages automatically on pushes to the master branch